### PR TITLE
Create release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Clojars
+
+on:
+  push:
+    tags:
+    - '*'
+
+jobs:
+  release:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install dependencies
+      run: lein deps
+
+    - name: Run tests
+      run: lein test
+
+    - name: Publish
+      run: lein deploy publish
+      env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWD: ${{ secrets.CLOJARS_PASSWD }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,16 @@
+# Releasing
+
+To release a new version in Clojars, you need to run
+
+```bash
+./release.sh
+```
+
+This command creates a git tag with the project's current version and pushes it
+to github. This will trigger a GithubAction that tests and uploads JAR files to
+Clojars.
+
+### Credentials
+
+Credentials are configured as github secrets: `CLOJARS_USERNAME` and
+`CLOJARS_PASSWD`.

--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,13 @@
             :url  "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.10.0"]]
 
+  :repositories [["publish" {:url "https://clojars.org/repo"
+                             :username :env/clojars_username
+                             :password :env/clojars_passwd
+                             :sign-releases false}]]
+
+  :plugins [[lein-project-version "0.1.0"]]
+
   :profiles {:dev {:plugins [[lein-cljsbuild "1.1.7"]
                              [lein-doo "0.1.11"]]
                    :dependencies [[org.clojure/clojurescript "1.10.520"]]}}

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,6 @@
+#/bin/bash
+
+project_version="$(lein project-version | tail -n1)"
+
+git tag "$project_version"
+git push origin "$project_version"


### PR DESCRIPTION
This adds a Github Action that publishes new `mockfn` versions to Clojars. 
For more info please check RELEASING.md

### Before merging
 - [x] Add `eng-prod` user credentials as Github Secrets

### Open questions
Should we change the project's name to have a `nubank` namespace?