### PR TITLE
verifying throws NPE when arg to mocked fn in spec is an anon fn

### DIFF
--- a/src/mockfn/internal/macros.cljc
+++ b/src/mockfn/internal/macros.cljc
@@ -24,10 +24,12 @@
   describing a mock to be produced for every function in the bindings."
   [bindings]
   (reduce
-    (fn [acc [[func & args] ret-val & times-expected]]
-      (-> acc
-          (assoc-in [func :function] func)
-          (assoc-in [func :return-values (into [] args)] ret-val)
-          (assoc-in [func :times-called (into [] args)] `(atom 0))
-          (assoc-in [func :times-expected (into [] args)] (into [] times-expected))))
-    {} bindings))
+   (fn [acc [[func & args] ret-val & [verify-times-expected]]]
+     (-> acc
+         (assoc-in [func :stubbed/function] func)
+         (assoc-in [func :stubbed/calls (into [] args)]
+                   (cond-> {:providing/return-value ret-val}
+                     verify-times-expected
+                     (assoc :verifying/times-called   `(atom 0)
+                            :verifying/times-expected verify-times-expected)))))
+   {} bindings))

--- a/src/mockfn/macros.cljc
+++ b/src/mockfn/macros.cljc
@@ -23,6 +23,6 @@
   (let [specs# (->> bindings (partition 3) internal.macro/bindings->specification)]
     `(with-redefs ~(internal.macro/specification->redef-bindings specs#)
        (let [res# (do ~@body)]
-         (doseq [mock# (keys ~specs#)]
+         (doseq [mock# ~(into [] (keys specs#))]
            (mock/verify mock#))
          res#))))

--- a/src/mockfn/mock.cljc
+++ b/src/mockfn/mock.cljc
@@ -16,8 +16,8 @@
 
 (defn verify [mock]
   (let [spec (internal.mock/mock->spec mock)]
-    (doseq [args    (-> spec :times-expected keys)
-            matcher (-> spec :times-expected (get args))]
-      (let [times-called (-> spec :times-called (get args) deref)]
+    (doseq [[args stubbed-call] (:stubbed/calls spec)]
+      (let [matcher      (:verifying/times-expected stubbed-call)
+            times-called @(:verifying/times-called stubbed-call)]
         (when-not (matchers/matches? matcher times-called)
-          (throw (ex-info (internal.mock/matcher-failure-ex-msg (-> spec :function) args matcher times-called) {})))))))
+          (throw (ex-info (internal.mock/matcher-failure-ex-msg (-> spec :stubbed/function) args matcher times-called) {})))))))

--- a/test/mockfn/core_test.clj
+++ b/test/mockfn/core_test.clj
@@ -1,2 +1,0 @@
-(ns mockfn.core-test
-  (:require [clojure.test :refer :all]))

--- a/test/mockfn/internal/macros_test.cljc
+++ b/test/mockfn/internal/macros_test.cljc
@@ -16,33 +16,26 @@
 
   (testing "output includes functions"
     (is (= 'mockfn.fixtures/one-fn
-           (get-in specification ['mockfn.fixtures/one-fn :function])))
+           (get-in specification ['mockfn.fixtures/one-fn :stubbed/function])))
     (is (= 'mockfn.fixtures/other-fn
-           (get-in specification ['mockfn.fixtures/other-fn :function]))))
+           (get-in specification ['mockfn.fixtures/other-fn :stubbed/function]))))
 
   (testing "output includes return values for each function and argument list"
     (is (= :one-fn-return
-           (get-in specification ['mockfn.fixtures/one-fn :return-values []])))
+           (get-in specification ['mockfn.fixtures/one-fn :stubbed/calls [] :providing/return-value])))
     (is (= :one-fn-arg-return
-           (get-in specification ['mockfn.fixtures/one-fn :return-values [:arg]])))
+           (get-in specification ['mockfn.fixtures/one-fn :stubbed/calls [:arg] :providing/return-value])))
     (is (= :other-fn-return
-           (get-in specification ['mockfn.fixtures/other-fn :return-values []]))))
+           (get-in specification ['mockfn.fixtures/other-fn :stubbed/calls [] :providing/return-value]))))
 
   (testing "output includes atoms for counting calls for each function and argument list"
     (is (= '(clojure.core/atom 0)
-           (get-in specification ['mockfn.fixtures/one-fn :times-called []])))
-    (is (= '(clojure.core/atom 0)
-           (get-in specification ['mockfn.fixtures/one-fn :times-called [:arg]])))
-    (is (= '(clojure.core/atom 0)
-           (get-in specification ['mockfn.fixtures/other-fn :times-called []]))))
+           (get-in specification ['mockfn.fixtures/other-fn :stubbed/calls [] :verifying/times-called]))))
 
   (testing "output includes the call-count matcher for each function and argument list"
-    (is (= []
-           (get-in specification ['mockfn.fixtures/one-fn :times-expected []])))
-    (is (= []
-           (get-in specification ['mockfn.fixtures/one-fn :times-expected [:arg]])))
-    (is (= ['call-count-matcher]
-           (get-in specification ['mockfn.fixtures/other-fn :times-expected []])))))
+    (is (nil? (get-in specification ['mockfn.fixtures/one-fn :stubbed/calls [] :verifying/times-expected])))
+    (is (nil? (get-in specification ['mockfn.fixtures/one-fn :stubbed/calls [:arg] :verifying/times-expected])))
+    (is (= 'call-count-matcher (get-in specification ['mockfn.fixtures/other-fn :stubbed/calls [] :verifying/times-expected])))))
 
 (def redef-bindings
   (internal.macros/specification->redef-bindings specification))

--- a/test/mockfn/macros_test.cljc
+++ b/test/mockfn/macros_test.cljc
@@ -106,6 +106,15 @@
       [(#'fixtures/private-fn) :mocked-private (matchers/exactly 1)]
       (is (= :mocked-private (#'fixtures/private-fn)))))
 
+  (testing "matches anon fn arguments"
+    (macros/verifying [(fixtures/one-fn (fn [x] (= 1 x))) :a (matchers/exactly 1)]
+                      (is (= :a (fixtures/one-fn 1))))
+
+    (macros/verifying [(fixtures/one-fn (fn [x] (= 1 x))) :a (matchers/exactly 1)
+                       (fixtures/one-fn (fn [x] (= 2 x))) :a (matchers/exactly 1)]
+                      (is (= :a (fixtures/one-fn 1)))
+                      (is (= :a (fixtures/one-fn 2)))))
+
   (testing "fails if calls to private functions are not performed the expected number of times"
     (is (thrown-with-msg?
           ExceptionInfo #"Expected .* with arguments"


### PR DESCRIPTION
This PR addresses #4, supporting anonymous functions as function arguments in `verifying` expressions.

Additionally:
* added namespaces to internal data structures for clarification
* removed verification-specific keys when only providing

