### PR TITLE
Use authorization token to deploy on Clojars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Clojars
+name: Release
 
 on:
   push:
@@ -22,8 +22,8 @@ jobs:
     - name: Run cljs tests
       run: lein test-node
 
-    - name: Publish
+    - name: Publish on Clojars
       run: lein deploy publish
       env:
-          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
-          CLOJARS_PASSWD: ${{ secrets.CLOJARS_PASSWD }}
+          CLOJARS_USERNAME: eng-prod-nubank
+          CLOJARS_PASSWD: ${{ secrets.CLOJARS_DEPLOY_TOKEN }}


### PR DESCRIPTION
Clojars changed its authorization to use [Deploy Tokens](https://github.com/clojars/clojars-web/wiki/Deploy-Tokens).
This also stops using a [secret](https://github.com/nubank/mockfn/settings/secrets) for Clojars username because this info is not private.