### PR TITLE
clarify unexpected unmocked error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project are documented in this file.
 
+### 0.7.0 - 2021-06-11
+- Introduce `mockfn.matchers/any-args?`: a matcher that's always satisfied regardless of the number or form of arguments it matches against
+- Improve error message when a function being mocked doesn't have a matching mock case.
+- Deprecate `mockfn.macros/unmocked` in favor of `mockfn.macros/fall-through` for the sake of clarity.
+
 ### 0.6.1 - 2020-04-15
 - `verifying` now supports anon functions as args [#4](https://github.com/nubank/mockfn/pull/4),[#5](https://github.com/nubank/mockfn/pull/5)
 

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -61,12 +61,12 @@ If you would like to call the value instead of returning it, use `mockfn.macros/
 
 #### `fall-through`
 
-When mocking it is sometimes useful to set some mocks to point to their
-original implementation. This can be done by using `mockfn.macros/fall-through`:
+When mocking a function, it is sometimes useful to allow calls with specific
+arguments to fall through to their original implementation:
 
 ```clj
 (testing "providing - using fall-through to default to original function"
-  (providing [(one-fn :argument-1) fall-through
+  (providing [(one-fn :argument-1) mockfn.macros/fall-through
               (one-fn :argument-2) :result-2]
     (is (thrown? ExceptionInfo (one-fn)))))
 ```

--- a/doc/documentation.md
+++ b/doc/documentation.md
@@ -59,14 +59,14 @@ If you would like to call the value instead of returning it, use `mockfn.macros/
     (is (thrown? ExceptionInfo (one-fn)))))
 ```
 
-#### `unmocked`
+#### `fall-through`
 
 When mocking it is sometimes useful to set some mocks to point to their
-original implementation. This can be done by using `mockfn.macros/unmocked`:
+original implementation. This can be done by using `mockfn.macros/fall-through`:
 
 ```clj
-(testing "providing - using unmocked to default to original function"
-  (providing [(one-fn :argument-1) unmocked
+(testing "providing - using fall-through to default to original function"
+  (providing [(one-fn :argument-1) fall-through
               (one-fn :argument-2) :result-2]
     (is (thrown? ExceptionInfo (one-fn)))))
 ```

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject nubank/mockfn "0.6.1"
+(defproject nubank/mockfn "0.7.0"
   :description "A library for mocking Clojure functions."
   :url "https://github.com/pmatiello/mockfn"
   :license {:name "Eclipse Public License"

--- a/src/mockfn/internal/matchers.cljc
+++ b/src/mockfn/internal/matchers.cljc
@@ -19,4 +19,5 @@
   [expected args]
   (let [arity-matches?    (= (count expected) (count args))
         each-arg-matches? (every? matches-arg? (map vector expected args))]
-    (and arity-matches? each-arg-matches?)))
+    (or (= expected [matchers/any-args?])
+        (and arity-matches? each-arg-matches?))))

--- a/src/mockfn/internal/mock.cljc
+++ b/src/mockfn/internal/mock.cljc
@@ -32,11 +32,19 @@
 (defn- unexpected-call-msg
   "Exception message for unexpected call."
   [func args]
-  (utils/formatted
-    "An unexpected unmocked call to %s was made with %d argument(s): %s"
-    (func-or-unbound-var func)
-    (count args)
-    args))
+  (let [f (func-or-unbound-var func)]
+    (utils/formatted
+      "%s was specified as mocked but none of the cases matched the %d provided argument(s):
+  %s
+
+Either
+ - specify a mock case for those arguments
+ - specify falling through to the original functionality via a terminal match clause:
+  `(%s mockfn.matchers/any-args?) mockfn.macros/fall-through"
+      f
+      (count args)
+      args
+      f)))
 
 (defn- map-vals [f m]
   (into {} (for [[k v] m] [k (f v)])))

--- a/src/mockfn/internal/mock.cljc
+++ b/src/mockfn/internal/mock.cljc
@@ -31,8 +31,11 @@
 (defn- unexpected-call-msg
   "Exception message for unexpected call."
   [func args]
-  (utils/formatted "Unexpected call to %s with args %s"
-                   (func-or-unbound-var func) args))
+  (utils/formatted
+    "An unexpected unmocked call to %s was made with %d argument(s): %s"
+    (func-or-unbound-var func)
+    (count args)
+    args))
 
 (defn- extract [spec args prop]
   (for-args

--- a/src/mockfn/internal/mock.cljc
+++ b/src/mockfn/internal/mock.cljc
@@ -28,7 +28,7 @@
   "Returns the given function or an \"<unbound var>\" string if the
   function is nil (cljs doesn't have unbound vars)."
   [func]
-  (or (string/replace-first (str func) "Unbound: #'" "")
+  (or (some-> func str (string/replace-first "Unbound: #'" ""))
       "<unbound var>"))
 
 (defn- unexpected-call-msg

--- a/src/mockfn/internal/mock.cljc
+++ b/src/mockfn/internal/mock.cljc
@@ -1,5 +1,6 @@
 (ns mockfn.internal.mock
-  (:require [mockfn.internal.utils :as utils]
+  (:require [clojure.string :as string]
+            [mockfn.internal.utils :as utils]
             [mockfn.internal.matchers :as internal.matchers]
             [mockfn.matchers :as matchers]))
 
@@ -27,7 +28,8 @@
   "Returns the given function or an \"<unbound var>\" string if the
   function is nil (cljs doesn't have unbound vars)."
   [func]
-  (or func "<unbound var>"))
+  (or (string/replace-first (str func) "Unbound: #'" "")
+      "<unbound var>"))
 
 (defn- unexpected-call-msg
   "Exception message for unexpected call."

--- a/src/mockfn/internal/mock.cljc
+++ b/src/mockfn/internal/mock.cljc
@@ -13,13 +13,14 @@
       matchers)))
 
 (defn- for-args
-  "Takes a map m where the keys are lists of matchers. Retrieves from this
-  map a value for which the list args fulfill the list of matchers in the key.
+  "Takes a map `arg-matchers->result` where the keys are lists of matchers.
+  Retrieves from this map a value for which the list args fulfill the list of
+  matchers in the key.
 
   If args doesn't satisfy any list of matchers, returns ::unexpected-call."
-  [m args]
-  (if-let [expected (some (matching-fn-for args) (keys m))]
-    (get m expected)
+  [arg-matchers->result args]
+  (if-let [expected (some (matching-fn-for args) (keys arg-matchers->result))]
+    (get arg-matchers->result expected)
     ::unexpected-call))
 
 (defn- func-or-unbound-var
@@ -37,12 +38,12 @@
     (count args)
     args))
 
+(defn- map-vals [f m]
+  (into {} (for [[k v] m] [k (f v)])))
+
 (defn- extract [spec args prop]
-  (for-args
-   (into {} (map
-             (fn [[k v]] [k (get v prop)])
-             (:stubbed/calls spec)))
-   args))
+  (let [arg-matchers->result (map-vals #(get % prop) (:stubbed/calls spec))]
+    (for-args arg-matchers->result args)))
 
 (defn- ensure-expected-call
   "Throws an exception if the given call is unexpected."

--- a/src/mockfn/macros.cljc
+++ b/src/mockfn/macros.cljc
@@ -7,9 +7,15 @@
   "Invoke mocked value as a function instead of returning it."
   [func] (mock/calling func))
 
-(def unmocked
+(def fall-through
   "Invoke the original implementation of the mocked function."
   (mock/calling-original))
+
+(def unmocked
+  "DEPRECATED: renamed to `fall-through`
+
+  Invoke the original implementation of the mocked function."
+  fall-through)
 
 (defmacro providing
   "Mocks functions."

--- a/src/mockfn/matchers.cljc
+++ b/src/mockfn/matchers.cljc
@@ -52,3 +52,13 @@
                      (str predicate))))
 
 (def pred ->Predicate)
+
+(def any-args?
+  "A special directive that always matches regardless of the number or form of
+  arguments provided. Useful as a terminal fall-through case when mocking.
+
+  For example:
+  (providing [(inc any-args?) :placeholder-inc-result]
+    (inc 1) ;=> :placeholder-inc-result
+    (inc 1 2 3 4) ;=> :placeholder-inc-result)"
+  ::any-args?)

--- a/test/mockfn/examples/basic_usage.cljc
+++ b/test/mockfn/examples/basic_usage.cljc
@@ -43,8 +43,8 @@
       (is (= :odd (one-fn 1)))
       (is (= :inc-fn (one-fn inc)))))
 
-  (testing "providing - unmocked"
-    (mfn/providing [(implemented-fn :argument-1) mfn/unmocked
+  (testing "providing - fall-through"
+    (mfn/providing [(implemented-fn :argument-1) mfn/fall-through
                     (implemented-fn :argument-2) :result-2]
       (is (= :argument-1 (implemented-fn :argument-1)))
       (is (= :result-2 (implemented-fn :argument-2)))))

--- a/test/mockfn/examples/basic_usage.cljc
+++ b/test/mockfn/examples/basic_usage.cljc
@@ -49,6 +49,12 @@
       (is (= :argument-1 (implemented-fn :argument-1)))
       (is (= :result-2 (implemented-fn :argument-2)))))
 
+  (testing "providing - fall-through via any-args?"
+    (mfn/providing [(implemented-fn :argument-1) :result-1
+                    (implemented-fn matchers/any-args?) :result-any]
+      (is (= :result-1 (implemented-fn :argument-1)))
+      (is (= :result-any (implemented-fn :argument-2)))))
+
   (testing "verifying"
     (mfn/verifying [(one-fn :argument) :result (matchers/exactly 1)]
       (is (= :result (one-fn :argument)))))

--- a/test/mockfn/macros_test.cljc
+++ b/test/mockfn/macros_test.cljc
@@ -26,10 +26,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unexpected call"
+            ExceptionInfo #"An unexpected"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unexpected call"
+            ExceptionInfo #"An unexpected"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -37,7 +37,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unexpected call"
+            ExceptionInfo #"An unexpected"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"
@@ -73,10 +73,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unexpected call"
+            ExceptionInfo #"An unexpected"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unexpected call"
+            ExceptionInfo #"An unexpected"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -84,7 +84,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked (matchers/exactly 1)]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unexpected call"
+            ExceptionInfo #"An unexpected"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"

--- a/test/mockfn/macros_test.cljc
+++ b/test/mockfn/macros_test.cljc
@@ -26,10 +26,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -37,7 +37,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"
@@ -73,10 +73,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -84,7 +84,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked (matchers/exactly 1)]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"
@@ -121,7 +121,3 @@
           (macros/verifying
             [(#'fixtures/private-fn) :mocked (matchers/exactly 2)]
             (is (= :mocked (#'fixtures/private-fn))))))))
-
-(macros/verifying
-  [(fixtures/one-fn (matchers/a Keyword)) :mocked (matchers/exactly 1)]
-  (fixtures/one-fn "unexpected"))

--- a/test/mockfn/macros_test.cljc
+++ b/test/mockfn/macros_test.cljc
@@ -26,10 +26,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #" was specified as mocked"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #" was specified as mocked"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -37,7 +37,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #" was specified as mocked"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"
@@ -73,10 +73,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #" was specified as mocked"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #" was specified as mocked"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -84,7 +84,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked (matchers/exactly 1)]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"mockfn.fixtures/one-fn was specified as mocked"
+            ExceptionInfo #" was specified as mocked"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"

--- a/test/mockfn/macros_test.cljc
+++ b/test/mockfn/macros_test.cljc
@@ -26,10 +26,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"An unexpected"
+            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"An unexpected"
+            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -37,7 +37,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"An unexpected"
+            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"
@@ -73,10 +73,10 @@
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (= :also-mocked (fixtures/one-fn :expected :also-expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"An unexpected"
+            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn :unexpected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"An unexpected"
+            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn)))))
 
   (testing "mocks functions with argument matchers"
@@ -84,7 +84,7 @@
       [(fixtures/one-fn (matchers/a Keyword)) :mocked (matchers/exactly 1)]
       (is (= :mocked (fixtures/one-fn :expected)))
       (is (thrown-with-msg?
-            ExceptionInfo #"An unexpected"
+            ExceptionInfo #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
             (fixtures/one-fn "unexpected")))))
 
   (testing "mocks multiple functions at once"
@@ -121,3 +121,7 @@
           (macros/verifying
             [(#'fixtures/private-fn) :mocked (matchers/exactly 2)]
             (is (= :mocked (#'fixtures/private-fn))))))))
+
+(macros/verifying
+  [(fixtures/one-fn (matchers/a Keyword)) :mocked (matchers/exactly 1)]
+  (fixtures/one-fn "unexpected"))

--- a/test/mockfn/mock_test.cljc
+++ b/test/mockfn/mock_test.cljc
@@ -18,15 +18,15 @@
       (is (= nil (stub :nil))))
 
     (testing "throws exception when called with unexpected arguments"
-      (let [message-regex #?(:clj #"An unexpected unmocked call to Unbound: #'mockfn.fixtures/one-fn was made with 2 argument\(s\): \[:unexpected-a :unexpected-b\]"
-                             :cljs #"An unexpected unmocked call to <unbound var> was made with 2 argument\(s\): \[:unexpected-a :unexpected-b\]")]
+      (let [message-regex #?(:clj #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+                             :cljs #"<unbound var> was specified as mocked")]
         (is (thrown-with-msg?
               ExceptionInfo message-regex
               (stub :unexpected-a :unexpected-b)))))
 
     (testing "throws exception when called with 1 unexpected argument"
-      (let [message-regex #?(:clj #"An unexpected unmocked call to Unbound: #'mockfn.fixtures/one-fn was made with 1 argument\(s\): \[:unexpected\]"
-                             :cljs #"An unexpected unmocked call to <unbound var> was made with 1 argument\(s\): \[:unexpected\]")]
+      (let [message-regex #?(:clj #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+                             :cljs #"<unbound var> was specified as mocked")]
         (is (thrown-with-msg?
               ExceptionInfo message-regex
               (stub :unexpected)))))))
@@ -82,8 +82,8 @@
       (is (= [:arg1 :arg2] (mock :arg1 :arg2))))
 
     (testing "throws exception when called with unexpected arguments"
-      (let [message-regex #?(:clj #"An unexpected unmocked call to Unbound: #'mockfn.fixtures/one-fn was made with 1 argument\(s\): \[:unexpected\]"
-                             :cljs #"An unexpected unmocked call to <unbound var> was made with 1 argument\(s\): \[:unexpected\]")]
+      (let [message-regex #?(:clj #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+                             :cljs #"<unbound var> was specified as mocked")]
         (is (thrown-with-msg?
               ExceptionInfo
               message-regex

--- a/test/mockfn/mock_test.cljc
+++ b/test/mockfn/mock_test.cljc
@@ -18,14 +18,14 @@
       (is (= nil (stub :nil))))
 
     (testing "throws exception when called with unexpected arguments"
-      (let [message-regex #?(:clj #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+      (let [message-regex #?(:clj #"mockfn.fixtures/one-fn was specified as mocked"
                              :cljs #"<unbound var> was specified as mocked")]
         (is (thrown-with-msg?
               ExceptionInfo message-regex
               (stub :unexpected-a :unexpected-b)))))
 
     (testing "throws exception when called with 1 unexpected argument"
-      (let [message-regex #?(:clj #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+      (let [message-regex #?(:clj #"mockfn.fixtures/one-fn was specified as mocked"
                              :cljs #"<unbound var> was specified as mocked")]
         (is (thrown-with-msg?
               ExceptionInfo message-regex
@@ -82,7 +82,7 @@
       (is (= [:arg1 :arg2] (mock :arg1 :arg2))))
 
     (testing "throws exception when called with unexpected arguments"
-      (let [message-regex #?(:clj #"Unbound: #'mockfn.fixtures/one-fn was specified as mocked"
+      (let [message-regex #?(:clj #"mockfn.fixtures/one-fn was specified as mocked"
                              :cljs #"<unbound var> was specified as mocked")]
         (is (thrown-with-msg?
               ExceptionInfo

--- a/test/mockfn/mock_test.cljc
+++ b/test/mockfn/mock_test.cljc
@@ -18,8 +18,15 @@
       (is (= nil (stub :nil))))
 
     (testing "throws exception when called with unexpected arguments"
-      (let [message-regex #?(:clj #"Unexpected call to Unbound: #'mockfn.fixtures/one-fn with args \[:unexpected\]"
-                             :cljs #"Unexpected call to <unbound var> with args \[:unexpected\]")]
+      (let [message-regex #?(:clj #"An unexpected unmocked call to Unbound: #'mockfn.fixtures/one-fn was made with 2 argument\(s\): \[:unexpected-a :unexpected-b\]"
+                             :cljs #"An unexpected unmocked call to <unbound var> was made with 2 argument\(s\): \[:unexpected-a :unexpected-b\]")]
+        (is (thrown-with-msg?
+              ExceptionInfo message-regex
+              (stub :unexpected-a :unexpected-b)))))
+
+    (testing "throws exception when called with 1 unexpected argument"
+      (let [message-regex #?(:clj #"An unexpected unmocked call to Unbound: #'mockfn.fixtures/one-fn was made with 1 argument\(s\): \[:unexpected\]"
+                             :cljs #"An unexpected unmocked call to <unbound var> was made with 1 argument\(s\): \[:unexpected\]")]
         (is (thrown-with-msg?
               ExceptionInfo message-regex
               (stub :unexpected)))))))
@@ -75,8 +82,8 @@
       (is (= [:arg1 :arg2] (mock :arg1 :arg2))))
 
     (testing "throws exception when called with unexpected arguments"
-      (let [message-regex #?(:clj #"Unexpected call to Unbound: #'mockfn.fixtures/one-fn with args \[:unexpected\]"
-                             :cljs #"Unexpected call to <unbound var> with args \[:unexpected\]")]
+      (let [message-regex #?(:clj #"An unexpected unmocked call to Unbound: #'mockfn.fixtures/one-fn was made with 1 argument\(s\): \[:unexpected\]"
+                             :cljs #"An unexpected unmocked call to <unbound var> was made with 1 argument\(s\): \[:unexpected\]")]
         (is (thrown-with-msg?
               ExceptionInfo
               message-regex

--- a/test/mockfn/mock_test.cljc
+++ b/test/mockfn/mock_test.cljc
@@ -70,7 +70,7 @@
       (is (= :odd (mock 1)))
       (is (= :matchers-any (mock "anything"))))))
 
-(deftest mock-unmocked
+(deftest mock-fall-through
   (let [definition {:stubbed/function (fn [& args] args)
                     :stubbed/calls    {[]            {:providing/return-value (mock/calling-original)}
                                        [:arg1]       {:providing/return-value (mock/calling-original)}


### PR DESCRIPTION
for something unmocked like
```clojure
(ns mockfn.scratch
  (:require [mockfn.macros :refer [providing unmocked]]))

(defn bar [x y] 1)
(defn foo []
  (bar "b" 1))

(providing [(bar "a" 1) nil]
 (foo))
```
we used to get the error message

```
Unexpected call to mockfn.scratch$bar@c695421 with args ["b" 1]
```

and this PR changes it to be
```
Syntax error (ExceptionInfo) compiling at (mockfn/macros_test.cljc:125:1).
mockfn.fixtures/one-fn was specified as mocked but none of the cases matched the 1 provided argument(s):
  ["unexpected"]

Either
 - specify a mock case for those arguments
 - specify falling through to the original functionality via a terminal match clause:
  `(mockfn.fixtures/one-fn mockfn.matchers/any-args?) mockfn.macros/fall-through
```

I'm proposing this change because it feels a bit more in-line with the fix which is to add an `unmocked` entry:
```clojure
(providing [(bar "a" 1) nil
            (bar "b" 1) unmocked]
 (foo))
```

additionally:

 - implemented any-args? (appropriate name?) to match irregardless of # of args provided
 - deprecated `unmocked` and replaced it with `fall-through`